### PR TITLE
Feature: appxmanifest configuration

### DIFF
--- a/src/Band.Personalize/Band.Personalize.App.Universal/Package.appxmanifest
+++ b/src/Band.Personalize/Band.Personalize.App.Universal/Package.appxmanifest
@@ -19,6 +19,12 @@
         <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
         </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
+        <uap:InitialRotationPreference>
+          <uap:Rotation Preference="portrait" />
+          <uap:Rotation Preference="landscape" />
+          <uap:Rotation Preference="portraitFlipped" />
+          <uap:Rotation Preference="landscapeFlipped" />
+        </uap:InitialRotationPreference>
       </uap:VisualElements>
     </Application>
   </Applications>

--- a/src/Band.Personalize/Band.Personalize.App.Universal/Package.appxmanifest
+++ b/src/Band.Personalize/Band.Personalize.App.Universal/Package.appxmanifest
@@ -1,49 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-  <Identity
-    Name="f7e882a2-9ab7-4fb3-9f32-d833a465b7fb"
-    Publisher="CN=butchern"
-    Version="1.0.0.0" />
-
-  <mp:PhoneIdentity PhoneProductId="f7e882a2-9ab7-4fb3-9f32-d833a465b7fb" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="f7e882a2-9ab7-4fb3-9f32-d833a465b7fb" Publisher="CN=butchern" Version="0.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="f7e882a2-9ab7-4fb3-9f32-d833a465b7fb" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
-    <DisplayName>Band.Personalize.App.Universal</DisplayName>
-    <PublisherDisplayName>butchern</PublisherDisplayName>
+    <DisplayName>Band.Personalize</DisplayName>
+    <PublisherDisplayName>Nick Butcher</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
-
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
-
   <Resources>
-    <Resource Language="x-generate"/>
+    <Resource Language="x-generate" />
   </Resources>
-
   <Applications>
-    <Application Id="App"
-      Executable="$targetnametoken$.exe"
-      EntryPoint="Band.Personalize.App.Universal.App">
-      <uap:VisualElements
-        DisplayName="Band.Personalize.App.Universal"
-        Square150x150Logo="Assets\Square150x150Logo.png"
-        Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="Band.Personalize.App.Universal"
-        BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+    <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="Band.Personalize.App.Universal.App">
+      <uap:VisualElements DisplayName="Band.Personalize" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="A personalization tool for the Microsoft Band and Microsoft Band 2, built on the Universal Windows Platform." BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>
-
   <Capabilities>
-    <Capability Name="internetClient" />
+    <DeviceCapability Name="bluetooth" />
   </Capabilities>
 </Package>

--- a/src/Band.Personalize/Band.Personalize.Model.Test/Package.appxmanifest
+++ b/src/Band.Personalize/Band.Personalize.Model.Test/Package.appxmanifest
@@ -1,45 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Package
-  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
-  xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
-  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
-
-  <Identity Name="e6b41e07-ed01-4e88-ad41-65f3958e0a8b"
-            Publisher="CN=butchern"
-            Version="1.0.0.0" />
-
-  <mp:PhoneIdentity PhoneProductId="e6b41e07-ed01-4e88-ad41-65f3958e0a8b" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
-
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
+  <Identity Name="e6b41e07-ed01-4e88-ad41-65f3958e0a8b" Publisher="CN=butchern" Version="0.0.0.0" />
+  <mp:PhoneIdentity PhoneProductId="e6b41e07-ed01-4e88-ad41-65f3958e0a8b" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>Band.Personalize.Model.Test</DisplayName>
-    <PublisherDisplayName>butchern</PublisherDisplayName>
+    <PublisherDisplayName>Nick Butcher</PublisherDisplayName>
     <Logo>Assets\StoreLogo.png</Logo>
   </Properties>
-  
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.0.0" MaxVersionTested="10.0.0.0" />
   </Dependencies>
-
   <Resources>
     <Resource Language="x-generate" />
   </Resources>
   <Applications>
-    <Application Id="vstest.executionengine.universal.App" 
-        Executable="$targetnametoken$.exe"
-        EntryPoint="Band.Personalize.Model.Test.App">
-      <uap:VisualElements
-        DisplayName="Band.Personalize.Model.Test"
-        Square150x150Logo="Assets\Square150x150Logo.png"
-        Square44x44Logo="Assets\Square44x44Logo.png"
-        Description="Band.Personalize.Model.Test"
-        BackgroundColor="transparent">
-        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png"/>
+    <Application Id="vstest.executionengine.universal.App" Executable="$targetnametoken$.exe" EntryPoint="Band.Personalize.Model.Test.App">
+      <uap:VisualElements DisplayName="Band.Personalize.Model.Test" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png" Description="Band.Personalize.Model.Test" BackgroundColor="transparent">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png">
+        </uap:DefaultTile>
         <uap:SplashScreen Image="Assets\SplashScreen.png" />
       </uap:VisualElements>
     </Application>
   </Applications>
-  <Capabilities>
-    <Capability Name="internetClient" />
-  </Capabilities> 
 </Package>


### PR DESCRIPTION
Add friendly names and required configuration to the appxmanifest.

Band.Personalize will support all rotations, and requires Bluetooth access (for connecting to paired Bands).
