### PR TITLE
Bug: fix inconsistent assembly references

### DIFF
--- a/src/Band.Personalize.App.Universal/Band.Personalize.App.Universal.csproj
+++ b/src/Band.Personalize.App.Universal/Band.Personalize.App.Universal.csproj
@@ -267,4 +267,10 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="CodeWarningRemover" AfterTargets="MarkupCompilePass2">
+    <ItemGroup>
+      <GeneratedFiles Include="**\*.g.cs;**\*.g.i.cs" />
+    </ItemGroup>
+    <Exec Command="for %%f in (@(GeneratedFiles->'%22%(Identity)%22')) do echo #pragma warning disable CS1591 > %%f.pragmatemp &amp; type %%f >> %%f.pragmatemp &amp; echo #pragma warning restore CS1591 >> %%f.pragmatemp &amp; copy /y %%f.pragmatemp %%f &amp; del /F %%f.pragmatemp" />
+  </Target>
 </Project>

--- a/src/Band.Personalize.ruleset
+++ b/src/Band.Personalize.ruleset
@@ -64,6 +64,10 @@
     <Rule Id="CA2241" Action="Warning" />
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="CS1701" Action="None" />
+    <Rule Id="CS1702" Action="None" />
+  </Rules>
   <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp.Features" RuleNamespace="Microsoft.CodeAnalysis.CSharp.Features">
     <Rule Id="IDE0003" Action="None" />
   </Rules>


### PR DESCRIPTION
Resolves #23 

Also addresses comment warnings form generated code.

Only remaining warning is not under my control:

`The assembly "C:\Users\butchern\.nuget\packages\Moq\4.6.36-alpha\lib\netstandard1.3\Moq.dll" does not have a NeutralResourcesLanguageAttribute on it. To be used in an app package, portable libraries must define a NeutralResourcesLanguageAttribute on their main assembly (ie, the one containing code, not a satellite assembly).`

I will be working on moq/moq4#274, which may help resolve this warning.
